### PR TITLE
Load seq.el for using its functions

### DIFF
--- a/org-working-set.el
+++ b/org-working-set.el
@@ -152,6 +152,7 @@
 (require 'org)
 (require 'dash)
 (require 's)
+(require 'seq)
 
 
 ;;; customizable options


### PR DESCRIPTION
And fix following byte-compile warnings

```
org-working-set.el:1142:1:Warning: the following functions are not known to be defined: seq-intersection,
    seq-difference
```